### PR TITLE
Upgrade System.Data.SqlClient

### DIFF
--- a/source/org.ohdsi.cdm.framework.common/org.ohdsi.cdm.framework.common.csproj
+++ b/source/org.ohdsi.cdm.framework.common/org.ohdsi.cdm.framework.common.csproj
@@ -9,4 +9,9 @@
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
 </Project>

--- a/source/org.ohdsi.cdm.framework.desktop/org.ohdsi.cdm.framework.desktop.csproj
+++ b/source/org.ohdsi.cdm.framework.desktop/org.ohdsi.cdm.framework.desktop.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="Npgsql" Version="5.0.0" />
     <PackageReference Include="Parquet.Net" Version="3.8.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.Odbc" Version="6.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cerner/org.ohdsi.cdm.framework.etl.cerner.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cerner/org.ohdsi.cdm.framework.etl.cerner.csproj
@@ -95,6 +95,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.common/org.ohdsi.cdm.framework.etl.common.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.common/org.ohdsi.cdm.framework.etl.common.csproj
@@ -582,4 +582,9 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
 </Project>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprd/org.ohdsi.cdm.framework.etl.cprd.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprd/org.ohdsi.cdm.framework.etl.cprd.csproj
@@ -106,6 +106,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprdhes/org.ohdsi.cdm.framework.etl.cprdhes.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprdhes/org.ohdsi.cdm.framework.etl.cprdhes.csproj
@@ -63,6 +63,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.hcup/org.ohdsi.cdm.framework.etl.hcup.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.hcup/org.ohdsi.cdm.framework.etl.hcup.csproj
@@ -47,6 +47,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.healthverity/org.ohdsi.cdm.framework.etl.healthverity.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.healthverity/org.ohdsi.cdm.framework.etl.healthverity.csproj
@@ -71,6 +71,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.ibm/org.ohdsi.cdm.framework.etl.ibm.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.ibm/org.ohdsi.cdm.framework.etl.ibm.csproj
@@ -135,6 +135,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.jmdc/org.ohdsi.cdm.framework.etl.jmdc.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.jmdc/org.ohdsi.cdm.framework.etl.jmdc.csproj
@@ -71,6 +71,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.nhanes/org.ohdsi.cdm.framework.etl.nhanes.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.nhanes/org.ohdsi.cdm.framework.etl.nhanes.csproj
@@ -27,6 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumextended/org.ohdsi.cdm.framework.etl.optumextended.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumextended/org.ohdsi.cdm.framework.etl.optumextended.csproj
@@ -147,6 +147,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumpanther/org.ohdsi.cdm.framework.etl.optumpanther.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumpanther/org.ohdsi.cdm.framework.etl.optumpanther.csproj
@@ -187,6 +187,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.premier/org.ohdsi.cdm.framework.etl.premier.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.premier/org.ohdsi.cdm.framework.etl.premier.csproj
@@ -127,6 +127,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.seer/org.ohdsi.cdm.framework.etl.seer.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.seer/org.ohdsi.cdm.framework.etl.seer.csproj
@@ -115,6 +115,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.symphonyemr/org.ohdsi.cdm.framework.etl.symphonyemr.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.symphonyemr/org.ohdsi.cdm.framework.etl.symphonyemr.csproj
@@ -83,6 +83,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\org.ohdsi.cdm.framework.common\org.ohdsi.cdm.framework.common.csproj" />
   </ItemGroup>
 

--- a/source/org.ohdsi.cdm.presentation.builder/org.ohdsi.cdm.presentation.builder.csproj
+++ b/source/org.ohdsi.cdm.presentation.builder/org.ohdsi.cdm.presentation.builder.csproj
@@ -17,8 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.Odbc" Version="6.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.presentation.builder/packages.config
+++ b/source/org.ohdsi.cdm.presentation.builder/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
-  <package id="MySqlConnector" version="0.64.2" targetFramework="net472" />
-  <package id="NBuilder" version="6.1.0" targetFramework="net472" />
-  <package id="Npgsql" version="4.1.3.1" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
-  <package id="System.Data.Odbc" version="4.7.0" targetFramework="net472" />
-  <package id="System.Data.SqlClient" version="4.8.1" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
-  <package id="System.Text.Json" version="4.7.1" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+	<package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+	<package id="MySqlConnector" version="0.64.2" targetFramework="net472" />
+	<package id="NBuilder" version="6.1.0" targetFramework="net472" />
+	<package id="Npgsql" version="4.1.3.1" targetFramework="net472" />
+	<package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+	<package id="System.Data.Odbc" version="4.7.0" targetFramework="net472" />
+	<package id="System.Data.SqlClient" version="4.8.6" targetFramework="net472" />
+	<package id="System.Memory" version="4.5.4" targetFramework="net472" />
+	<package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+	<package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+	<package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
+	<package id="System.Text.Json" version="4.7.1" targetFramework="net472" />
+	<package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+	<package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/source/org.ohdsi.cdm.presentation.builderwebapi/org.ohdsi.cdm.presentation.builderwebapi.csproj
+++ b/source/org.ohdsi.cdm.presentation.builderwebapi/org.ohdsi.cdm.presentation.builderwebapi.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded System.Data.SqlClient from version 4.8.2 to version 4.8.6 to fix Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass