### PR TITLE
Upgrade System.Text.Encodings.Web

### DIFF
--- a/source/org.ohdsi.cdm.framework.common/org.ohdsi.cdm.framework.common.csproj
+++ b/source/org.ohdsi.cdm.framework.common/org.ohdsi.cdm.framework.common.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/source/org.ohdsi.cdm.framework.desktop/org.ohdsi.cdm.framework.desktop.csproj
+++ b/source/org.ohdsi.cdm.framework.desktop/org.ohdsi.cdm.framework.desktop.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.Odbc" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cerner/org.ohdsi.cdm.framework.etl.cerner.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cerner/org.ohdsi.cdm.framework.etl.cerner.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.common/org.ohdsi.cdm.framework.etl.common.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.common/org.ohdsi.cdm.framework.etl.common.csproj
@@ -585,6 +585,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprd/org.ohdsi.cdm.framework.etl.cprd.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprd/org.ohdsi.cdm.framework.etl.cprd.csproj
@@ -108,6 +108,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprdhes/org.ohdsi.cdm.framework.etl.cprdhes.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.cprdhes/org.ohdsi.cdm.framework.etl.cprdhes.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.hcup/org.ohdsi.cdm.framework.etl.hcup.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.hcup/org.ohdsi.cdm.framework.etl.hcup.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.healthverity/org.ohdsi.cdm.framework.etl.healthverity.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.healthverity/org.ohdsi.cdm.framework.etl.healthverity.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.ibm/org.ohdsi.cdm.framework.etl.ibm.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.ibm/org.ohdsi.cdm.framework.etl.ibm.csproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.jmdc/org.ohdsi.cdm.framework.etl.jmdc.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.jmdc/org.ohdsi.cdm.framework.etl.jmdc.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.nhanes/org.ohdsi.cdm.framework.etl.nhanes.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.nhanes/org.ohdsi.cdm.framework.etl.nhanes.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumextended/org.ohdsi.cdm.framework.etl.optumextended.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumextended/org.ohdsi.cdm.framework.etl.optumextended.csproj
@@ -149,6 +149,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumpanther/org.ohdsi.cdm.framework.etl.optumpanther.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.optumpanther/org.ohdsi.cdm.framework.etl.optumpanther.csproj
@@ -189,6 +189,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.premier/org.ohdsi.cdm.framework.etl.premier.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.premier/org.ohdsi.cdm.framework.etl.premier.csproj
@@ -129,6 +129,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.seer/org.ohdsi.cdm.framework.etl.seer.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.seer/org.ohdsi.cdm.framework.etl.seer.csproj
@@ -117,6 +117,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.symphonyemr/org.ohdsi.cdm.framework.etl.symphonyemr.csproj
+++ b/source/org.ohdsi.cdm.framework.etl/org.ohdsi.cdm.framework.etl.symphonyemr/org.ohdsi.cdm.framework.etl.symphonyemr.csproj
@@ -85,6 +85,7 @@
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.presentation.builder/org.ohdsi.cdm.presentation.builder.csproj
+++ b/source/org.ohdsi.cdm.presentation.builder/org.ohdsi.cdm.presentation.builder.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.Odbc" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/org.ohdsi.cdm.presentation.builder/packages.config
+++ b/source/org.ohdsi.cdm.presentation.builder/packages.config
@@ -10,7 +10,7 @@
 	<package id="System.Memory" version="4.5.4" targetFramework="net472" />
 	<package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
 	<package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
-	<package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
+	<package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net472" />
 	<package id="System.Text.Json" version="4.7.1" targetFramework="net472" />
 	<package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 	<package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />

--- a/source/org.ohdsi.cdm.presentation.builderwebapi/org.ohdsi.cdm.presentation.builderwebapi.csproj
+++ b/source/org.ohdsi.cdm.presentation.builderwebapi/org.ohdsi.cdm.presentation.builderwebapi.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade System.Text.Encodings.Web from version 4.7.0 to version 4.7.2 to fix .NET Core Remote Code Execution Vulnerability