### PR TITLE
leave source_concept_id empty if there is no concept_id represent source_value in Athena

### DIFF
--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/MeasurementDataReader53.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/MeasurementDataReader53.cs
@@ -89,7 +89,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v53
                 case 15:
                     return _enumerator.Current.SourceValue;
                 case 16:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 17:
                     return _enumerator.Current.UnitSourceValue;
                 case 18:

--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/ObservationDataReader53.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/ObservationDataReader53.cs
@@ -84,7 +84,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v53
                 case 13:
                     return _enumerator.Current.SourceValue;
                 case 14:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 15:
                     return _enumerator.Current.UnitsSourceValue;
                 case 16:

--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/ProcedureOccurrenceDataReader53.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v53/ProcedureOccurrenceDataReader53.cs
@@ -79,7 +79,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v53
                 case 10:
                     return _enumerator.Current.SourceValue;
                 case 11:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 12:
                     return _enumerator.Current.QualifierSourceValue;
 

--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/MeasurementDataReader54.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/MeasurementDataReader54.cs
@@ -80,7 +80,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v54
                 case 15:
                     return _enumerator.Current.SourceValue;
                 case 16:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 17:
                     return _enumerator.Current.UnitSourceValue;
                 case 18:

--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/ObservationDataReader54.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/ObservationDataReader54.cs
@@ -81,7 +81,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v54
                 case 13:
                     return _enumerator.Current.SourceValue;
                 case 14:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 15:
                     return _enumerator.Current.UnitsSourceValue;
                 case 16:

--- a/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/ProcedureOccurrenceDataReader54.cs
+++ b/source/org.ohdsi.cdm.framework.common/DataReaders/v5/v54/ProcedureOccurrenceDataReader54.cs
@@ -78,7 +78,10 @@ namespace org.ohdsi.cdm.framework.common.DataReaders.v5.v54
                 case 10:
                     return _enumerator.Current.SourceValue;
                 case 11:
-                    return _enumerator.Current.SourceConceptId;
+                    if (_enumerator.Current.SourceConceptId == 0)
+                        return null;
+                    else
+                        return _enumerator.Current.SourceConceptId;
                 case 12:
                     return _enumerator.Current.QualifierSourceValue;
                 case 13:


### PR DESCRIPTION
leave source_concept_id empty if there is no concept_id represent source_value in Athena